### PR TITLE
Fix broken icon for chart view

### DIFF
--- a/ckanext/c3charts/plugin.py
+++ b/ckanext/c3charts/plugin.py
@@ -39,7 +39,7 @@ class ChartsPlugin(plugins.SingletonPlugin):
         }
 
         return {'name': 'Chart builder',
-                'icon': 'bar-chart',
+                'icon': 'bar-chart-o',
                 'filterable': True,
                 'iframed': False,
                 'schema': schema}


### PR DESCRIPTION
When creating a chart view, the icon is now shown because of the upgrade of Font Awesome to v4.0.3.